### PR TITLE
Automate installation of required certificates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !/libs/**
 !/src/**
 !pom.xml
+!start.sh
 
 # Ignore unnecessary files inside allowed directories
 # This should go after the allowed directories

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt install curl -y
 ENV HOME=/home/app
 WORKDIR $HOME
 COPY --from=build $HOME/target/*.jar app.jar
+COPY ./start.sh .
 
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","app.jar"]
-
+ENTRYPOINT ["bash","start.sh"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Move to this folder for all other commands.
 
 ### 3. Set it up :arrow_up:
 
+First, You need to add some hosts to your `/etc/hosts` file as mentioned [here](https://mgov.gov.in/PushSMS_Q1) on `mgov.gov.in` website.
+
+_Note: These ip addresses could subject to change so please make sure you are adding the correct ip addresses. You can use ping utility to identify the ip of a host._
+
+```
+164.100.129.128 mgov.gov.in
+164.100.129.141 msdgweb.mgov.gov.in
+```
+
 Run the following commands to see that _your local copy_ has a reference to _your forked remote repository_ in GitHub :octocat:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Move to this folder for all other commands.
 
 ### 3. Set it up :arrow_up:
 
-First, You need to add some hosts to your `/etc/hosts` file as mentioned [here](https://mgov.gov.in/PushSMS_Q1) on `mgov.gov.in` website.
+First, You need to add the required hosts to your `/etc/hosts` file as mentioned [here](https://mgov.gov.in/PushSMS_Q1) on `mgov.gov.in` website.
 
-_Note: These ip addresses could subject to change so please make sure you are adding the correct ip addresses. You can use ping utility to identify the ip of a host._
+_Note: These ip addresses are subject to change; so please ensure adding the correct ip addresses. You can use ping utility to identify the ip of a host on your local machine `ping msdgweb.mgov.gov.in`._
 
 ```
 164.100.129.128 mgov.gov.in

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+curl -O https://mgov.gov.in/Resources/TechnicalArticles/msdgweb-mgov-gov-in.crt
+
+eval "keytool -noprompt -storepass changeit -import -alias cdackey -keystore /usr/local/openjdk-11/lib/security/cacerts -file /home/app/msdgweb-mgov-gov-in.crt"
+
+echo "Added certificate"
+
+java -jar app.jar


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/Samagra-Development/uci-pwa/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Added a `start.sh` script which would add CDAC certificate to Java and then launches the app.

### Changes

* Add a start script
* Modify `Dockerfile` to copy `start.sh` script into the container